### PR TITLE
handles sign_document even if it is a string

### DIFF
--- a/lib/corp_pass/metadata.rb
+++ b/lib/corp_pass/metadata.rb
@@ -9,7 +9,7 @@ module CorpPass
       entity_descriptor = Saml::Elements::EntityDescriptor.new(entity_id: entity_id)
       entity_descriptor.sp_sso_descriptor = make_sp_descriptor(acs, encryption_crt, signing_crt, slo)
 
-      if sign_document
+      if sign_document == true || sign_document == 'true'
         sign(entity_descriptor, signing_crt, signing_key)
       else
         entity_descriptor.to_xml

--- a/spec/corp_pass/metadata_spec.rb
+++ b/spec/corp_pass/metadata_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe CorpPass::Metadata do
     expect(signed_document.signatures).to be_empty
   end
 
+  specify ':generate handles sign_document if it is given as a string' do
+    metadata = subject.generate(**@args.merge(sign_document: 'false'))
+    signed_document = Xmldsig::SignedDocument.new(metadata)
+    expect(signed_document.signatures).to be_empty
+
+    metadata = subject.generate(**@args.merge(sign_document: 'true'))
+    signed_document = Xmldsig::SignedDocument.new(metadata)
+    expect(signed_document.signatures).to be_present
+  end
+
   specify ':verify_signature verifies signature properly' do
     # The unicode characters are intentional
     unsigned = Saml::Response.new(in_response_to: 'αλ', status: Saml::TopLevelCodes::SUCCESS)


### PR DESCRIPTION
- fix an issue when sign_document accidentally passed as string (`if sign_document`, `if "false"` returning true)
- of all the inputs given to libcorppass this is the only boolean input, the rest are safe.